### PR TITLE
Lock Service to ELB Traffic

### DIFF
--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -405,17 +405,20 @@ export default {
                 GroupDescription: 'Allow access to TAK ports',
                 VpcId: cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-vpc'])),
                 SecurityGroupIngress: [{
-                    CidrIp: '0.0.0.0/0',
+                    Description: 'ELB Traffic',
+                    SourceSecurityGroupId: cf.ref('ELBSecurityGroup'),
                     IpProtocol: 'tcp',
                     FromPort: 8443,
                     ToPort: 8443
                 },{
-                    CidrIp: '0.0.0.0/0',
+                    Description: 'ELB Traffic',
+                    SourceSecurityGroupId: cf.ref('ELBSecurityGroup'),
                     IpProtocol: 'tcp',
                     FromPort: 8446,
                     ToPort: 8446
                 },{
-                    CidrIp: '0.0.0.0/0',
+                    Description: 'ELB Traffic',
+                    SourceSecurityGroupId: cf.ref('ELBSecurityGroup'),
                     IpProtocol: 'tcp',
                     FromPort: 8089,
                     ToPort: 8089


### PR DESCRIPTION
Per: https://github.com/dfpc-coe/security/issues/15

An Audit of ECS Service Security groups found that this SG is not locked to ELB traffic, allowing traffic to bypass the ELB if the ECS Task IP is known. Since the TAK Server manages it's own SSL this is not an issue per-say but violates best-practice.