### PR TITLE
Fixes various things to make TAK Server on Fargate working.

### DIFF
--- a/CoreConfig.js
+++ b/CoreConfig.js
@@ -44,7 +44,7 @@ const config = {
             },
             input: {
                 _attributes: {
-                    auth: 'x509',
+                    auth: 'ldap',
                     _name: 'stdssl',
                     protocol: 'tls',
                     port: '8089',
@@ -55,9 +55,10 @@ const config = {
                 _attributes: {
                     port: '8443',
                     _name: 'https',
-                    keystore: 'JKS',
-                    keystoreFile: `/opt/tak/certs/${process.env.HostedDomain}/letsencrypt.jks`,
-                    keystorePass: 'atakatak'
+                    // keystore: 'JKS',
+                    // keystoreFile: `/opt/tak/certs/files/${process.env.HostedDomain}/letsencrypt.jks`,
+                    // keystorePass: 'atakatak',
+                    enableNonAdminUI: 'true'
                 }
             }, {
                 _attributes: {
@@ -65,9 +66,9 @@ const config = {
                     clientAuth: 'false',
                     _name: 'cert_https',
                     keystore: 'JKS',
-                    keystoreFile: `/opt/tak/certs/${process.env.HostedDomain}/letsencrypt.jks`,
+                    keystoreFile: `/opt/tak/certs/files/${process.env.HostedDomain}/letsencrypt.jks`,
                     keystorePass: 'atakatak',
-                    enableNonAdminUI: 'false'
+                    enableNonAdminUI: 'true'
                 }
             }],
             announce: {
@@ -92,23 +93,13 @@ const config = {
                     groupNameExtractorRegex: 'CN=(.*?)(?:,|$)',
                     style: 'DS',
                     serviceAccountDN: `uid=ldapsvcaccount,${LDAP_DN}`,
-                    serviceAccountCredential: '',
+                    serviceAccountCredential: process.env.LDAP_Password,
                     groupObjectClass: 'groupOfNames',
                     groupBaseRDN: `ou=Group,${LDAP_DN}`,
                     ldapsTruststore: 'JKS',
-                    ldapsTruststoreFile: `${homedir}/aws-acm-root.jks`,
+                    ldapsTruststoreFile: '/opt/tak/aws-acm-root.jks',
                     ldapsTruststorePass: 'INTENTIONALLY_NOT_SENSITIVE',
                     enableConnectionPool: 'false'
-                }
-            },
-            File: {
-                _attributes: {
-                    location: 'UserAuthenticationFile.xml'
-                }
-            },
-            oauth: {
-                _attributes: {
-                    oauthUseGroupCache: 'true'
                 }
             }
         },

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM eclipse-temurin:17-jammy
 RUN apt update \
-    && apt-get install -y emacs-nox net-tools netcat vim certbot curl libxml2-utils unzip
+    && apt-get install -y emacs-nox net-tools netcat vim certbot curl libxml2-utils unzip nodejs awscli
 
-ENV HOME=/home/server
+ENV HOME=/opt/tak
 WORKDIR $HOME
 
 COPY ./ $HOME/
@@ -10,26 +10,26 @@ COPY ./ $HOME/
 EXPOSE 80
 EXPOSE 443
 EXPOSE 8443
-EXPOSE 8444
 EXPOSE 8446
+EXPOSE 9000
+EXPOSE 9001
 
 
 ENV NVM_DIR=/usr/local/nvm
 ENV NODE_VERSION=22
-ENV TAK_VERSION=takserver-docker-5.2-RELEASE-43
+ENV TAK_VERSION=takserver-docker-5.3-RELEASE-24
 
-RUN curl -o- https://www.amazontrust.com/repository/AmazonRootCA1.pem > /tmp/AmazonRootCA1.pem \
-    && openssl pkcs12 -export -nokeys -in /tmp/AmazonRootCA1.pem -out /tmp/intermediate.p12  -password pass:INTENTIONALLY_NOT_SENSITIVE \
-    && keytool -importkeystore -srckeystore /tmp/intermediate.p12 -srcstoretype PKCS12 -destkeystore ./aws-acm-root.jks -deststoretype JKS \
-    && rm /tmp/*.pem \
-    && rm /tmp/*.p12
-
-RUN wget "http://tak-server-releases.s3-website.us-gov-east-1.amazonaws.com/${TAK_VERSION}.zip" \
+RUN [ -e "./${TAK_VERSION}.zip" ] \
     && unzip "./${TAK_VERSION}.zip" \
     && rm "./${TAK_VERSION}.zip" \
     && rm -rf "./${TAK_VERSION}/docker" \
     && mv ./${TAK_VERSION}/tak/* ./ \
     && rm -rf "./${TAK_VERSION}"
+
+RUN mkdir -p /opt/tak/certs/files/ \
+    && curl -o- https://www.amazontrust.com/repository/AmazonRootCA1.pem > /tmp/AmazonRootCA1.pem \
+    && yes | keytool -import -file /tmp/AmazonRootCA1.pem -alias AWS -deststoretype JKS -deststorepass INTENTIONALLY_NOT_SENSITIVE -keystore /opt/tak/aws-acm-root.jks \
+    && rm /tmp/*.pem
 
 RUN mkdir -p $NVM_DIR \
     && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash \
@@ -40,4 +40,4 @@ RUN mkdir -p $NVM_DIR \
     && npm install \
     && npm install --global http-server
 
-ENTRYPOINT ["/bin/bash", "-c", "./start"]
+ENTRYPOINT ["/bin/bash", "-c", "/opt/tak/start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN mkdir -p $NVM_DIR \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default \
-    && npm install \
-    && npm install --global http-server
+    && npm install 
 
 ENTRYPOINT ["/bin/bash", "-c", "/opt/tak/start"]

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -205,14 +205,14 @@ export default {
             Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
             DependsOn: 'ELB',
             Properties: {
-                Port: 8446,
+                Port: 80,
                 Protocol: 'TCP',
                 TargetType: 'ip',
                 VpcId: cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-vpc'])),
 
                 HealthCheckEnabled: true,
                 HealthCheckIntervalSeconds: 30,
-                HealthCheckPort: 80,
+                HealthCheckPort: 8446,
                 HealthCheckProtocol: 'TCP',
                 HealthCheckTimeoutSeconds: 10,
                 HealthyThresholdCount: 2

--- a/cloudformation/lib/api.js
+++ b/cloudformation/lib/api.js
@@ -8,6 +8,11 @@ export default {
             AllowedValues: ['true', 'false'],
             Default: 'false'
         },
+        CertificateCountry: {
+            Description: '2 Letter Country Code',
+            Type: 'String',
+            Default: 'US'
+        },
         CertificateState: {
             Description: '2 Letter State Code',
             Type: 'String',
@@ -36,8 +41,14 @@ export default {
             Description: 'Hosted Email',
             Type: 'String'
         },
+        LetsencryptProdCert: {
+            Description: 'Issue Let\'s Encryp Production Certificate?',
+            Type: 'String',
+            AllowedValues: ['true', 'false'],
+            Default: 'false'
+        },
         LDAPDomain: {
-            Description: 'LDAPDomain',
+            Description: 'LDAP Domain',
             Type: 'String',
             Default: 'example.com'
         },
@@ -53,6 +64,14 @@ export default {
             Properties: {
                 LogGroupName: cf.stackName,
                 RetentionInDays: 7
+            }
+        },
+	TAKAdminP12Secret: {
+            Type: 'AWS::SecretsManager::Secret',
+            Properties: {
+                Description: cf.join([cf.stackName, ' TAK Server Admin key (p12)']),
+                Name: cf.join([cf.stackName, '/tak-admin-cert']),
+                KmsKeyId: cf.ref('KMS')
             }
         },
         ELB: {
@@ -84,6 +103,11 @@ export default {
                 },{
                     CidrIp: '0.0.0.0/0',
                     IpProtocol: 'tcp',
+                    FromPort: 80,
+                    ToPort: 80
+                },{
+                    CidrIp: '0.0.0.0/0',
+                    IpProtocol: 'tcp',
                     FromPort: 8443,
                     ToPort: 8443
                 },{
@@ -91,6 +115,11 @@ export default {
                     IpProtocol: 'tcp',
                     FromPort: 8446,
                     ToPort: 8446
+                },{
+                    CidrIp: '0.0.0.0/0',
+                    IpProtocol: 'tcp',
+                    FromPort: 8089,
+                    ToPort: 8089
                 }],
                 VpcId: cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-vpc']))
             }
@@ -100,10 +129,22 @@ export default {
             Properties: {
                 DefaultActions: [{
                     Type: 'forward',
-                    TargetGroupArn: cf.ref('TargetGroup8443')
+                    TargetGroupArn: cf.ref('TargetGroup8446')
                 }],
                 LoadBalancerArn: cf.ref('ELB'),
                 Port: 443,
+                Protocol: 'TCP'
+            }
+        },
+        Listener80: {
+            Type: 'AWS::ElasticLoadBalancingV2::Listener',
+            Properties: {
+                DefaultActions: [{
+                    Type: 'forward',
+                    TargetGroupArn: cf.ref('TargetGroup80')
+                }],
+                LoadBalancerArn: cf.ref('ELB'),
+                Port: 80,
                 Protocol: 'TCP'
             }
         },
@@ -157,7 +198,24 @@ export default {
                 HealthCheckPort: 8443,
                 HealthCheckProtocol: 'TCP',
                 HealthCheckTimeoutSeconds: 10,
-                HealthyThresholdCount: 5
+                HealthyThresholdCount: 2
+            }
+        },
+        TargetGroup80: {
+            Type: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+            DependsOn: 'ELB',
+            Properties: {
+                Port: 8446,
+                Protocol: 'TCP',
+                TargetType: 'ip',
+                VpcId: cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-vpc'])),
+
+                HealthCheckEnabled: true,
+                HealthCheckIntervalSeconds: 30,
+                HealthCheckPort: 80,
+                HealthCheckProtocol: 'TCP',
+                HealthCheckTimeoutSeconds: 10,
+                HealthyThresholdCount: 2
             }
         },
         TargetGroup8446: {
@@ -174,7 +232,7 @@ export default {
                 HealthCheckPort: 8446,
                 HealthCheckProtocol: 'TCP',
                 HealthCheckTimeoutSeconds: 10,
-                HealthyThresholdCount: 5
+                HealthyThresholdCount: 2
             }
         },
         TargetGroup8089: {
@@ -191,7 +249,7 @@ export default {
                 HealthCheckPort: 8089,
                 HealthCheckProtocol: 'TCP',
                 HealthCheckTimeoutSeconds: 10,
-                HealthyThresholdCount: 5
+                HealthyThresholdCount: 2
             }
         },
         TaskRole: {
@@ -235,6 +293,14 @@ export default {
                             ],
                             Resource: [
                                 cf.join(['arn:', cf.partition, ':secretsmanager:', cf.region, ':', cf.accountId, ':secret:', cf.stackName, '/*'])
+                            ]
+                        },{
+                            Effect: 'Allow',
+                            Action: [
+                                'secretsmanager:Put*'
+                            ],
+                            Resource: [
+                                cf.join(['arn:', cf.partition, ':secretsmanager:', cf.region, ':', cf.accountId, ':secret:', cf.stackName, '/tak-admin-cert'])
                             ]
                         }]
                     }
@@ -299,11 +365,13 @@ export default {
                     Name: 'api',
                     Image: cf.join([cf.accountId, '.dkr.ecr.', cf.region, '.amazonaws.com/coe-ecr-tak:', cf.ref('GitSha')]),
                     MountPoints: [{
-                        ContainerPath: '/opt/tak',
+                        ContainerPath: '/opt/tak/certs/files',
                         SourceVolume: cf.stackName
                     }],
                     PortMappings: [{
                         ContainerPort: 8443
+                    },{
+                        ContainerPort: 80
                     },{
                         ContainerPort: 8446
                     },{
@@ -325,6 +393,12 @@ export default {
                         Name: 'HostedDomain',
                         Value: cf.ref('HostedDomain')
                     },{
+                        Name: 'LetsencryptProdCert',
+                        Value: cf.ref('LetsencryptProdCert')
+                    },{
+                        Name: 'LDAP_Password',
+                        Value: cf.join(['{{resolve:secretsmanager:coe-auth-', cf.ref('Environment'), '/svc:SecretString:password:AWSCURRENT}}'])
+                    },{
                         Name: 'PostgresUsername',
                         Value: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/rds/secret:SecretString:username:AWSCURRENT}}')
                     },{
@@ -333,6 +407,9 @@ export default {
                     },{
                         Name: 'PostgresURL',
                         Value: cf.join(['postgresql://', cf.getAtt('DBInstance', 'Endpoint.Address'), ':5432/tak_ps_etl'])
+                    },{
+                        Name: 'COUNTRY',
+                        Value: cf.ref('CertificateCountry')
                     },{
                         Name: 'STATE',
                         Value: cf.ref('CertificateState')
@@ -386,6 +463,10 @@ export default {
                     TargetGroupArn: cf.ref('TargetGroup8443')
                 },{
                     ContainerName: 'api',
+                    ContainerPort: 80,
+                    TargetGroupArn: cf.ref('TargetGroup80')
+                },{
+                    ContainerName: 'api',
                     ContainerPort: 8446,
                     TargetGroupArn: cf.ref('TargetGroup8446')
                 },{
@@ -410,6 +491,12 @@ export default {
                     IpProtocol: 'tcp',
                     FromPort: 8443,
                     ToPort: 8443
+                },{
+                    Description: 'ELB Traffic',
+                    SourceSecurityGroupId: cf.ref('ELBSecurityGroup'),
+                    IpProtocol: 'tcp',
+                    FromPort: 80,
+                    ToPort: 80
                 },{
                     Description: 'ELB Traffic',
                     SourceSecurityGroupId: cf.ref('ELBSecurityGroup'),

--- a/cloudformation/lib/db.js
+++ b/cloudformation/lib/db.js
@@ -10,6 +10,11 @@ export default {
                 'db.t3.micro',
                 'db.m6g.large'
             ]
+        },
+        DatabaseVersion: {
+            Description: 'PostgreSQL database engine version',
+            Type: 'String',
+            Default: '17.4'
         }
     },
     Resources: {
@@ -67,7 +72,7 @@ export default {
                 MonitoringInterval: 60,
                 MonitoringRoleArn: cf.getAtt('DBMonitoringRole', 'Arn'),
                 KmsKeyId: cf.ref('KMS'),
-                EngineVersion: '16.2',
+                EngineVersion: cf.ref('DatabaseVersion'),
                 StorageEncrypted: true,
                 MasterUsername: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/rds/secret:SecretString:username:AWSCURRENT}}'),
                 MasterUserPassword: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/rds/secret:SecretString:password:AWSCURRENT}}'),

--- a/cloudformation/tak-infra.template.js
+++ b/cloudformation/tak-infra.template.js
@@ -1,15 +1,15 @@
 import cf from '@openaddresses/cloudfriend';
-import RDS from './lib/db.js';
+import DB from './lib/db.js';
 import API from './lib/api.js';
 import Alarms from './lib/alarms.js';
 import KMS from './lib/kms.js';
 import EFS from './lib/efs.js';
-import {
-    RDS as RDSAlarms
-} from '@openaddresses/batch-alarms';
+//import {
+//    RDS as RDSAlarms
+//} from '@openaddresses/batch-alarms';
 
 export default cf.merge(
-    API, RDS, KMS, Alarms, EFS,
+    API, DB, KMS, Alarms, EFS,
     {
         Description: 'Template for @tak-ps/tak-infra',
         Parameters: {
@@ -23,10 +23,10 @@ export default cf.merge(
                 Default: 'prod'
             }
         }
-    },
-    RDSAlarms({
-        prefix: 'Batch',
-        topic: cf.ref('AlarmTopic'),
-        instance: cf.ref('DBInstance')
-    })
+    }
+//    RDSAlarms({
+//       prefix: 'Batch',
+//       topic: cf.ref('AlarmTopic'),
+//       instance: cf.ref('DBInstance')
+//    })
 );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
     api:
         platform: linux/amd64
+        image: takserver
         build: .
         restart: 'always'
         links:

--- a/start
+++ b/start
@@ -9,19 +9,22 @@ set -x
 set -euo pipefail
 
 # Copy EFS Persisted certs to Let's Encrypt Dir
-if [ -d "/opt/tak/certs/${HostedDomain}" ]; then
+if [ -d "/opt/tak/certs/files/${HostedDomain}" ]; then
     mkdir -p "/etc/letsencrypt/live/${HostedDomain}"
-    ls "/opt/tak/certs/"
-    ls "/opt/tak/certs/${HostedDomain}/"
-    cp "/opt/tak/certs/${HostedDomain}/"* "/etc/letsencrypt/live/${HostedDomain}/"
+    ls "/opt/tak/certs/files/"
+    ls "/opt/tak/certs/files/${HostedDomain}/"
+    cp "/opt/tak/certs/files/${HostedDomain}/"* "/etc/letsencrypt/live/${HostedDomain}/"
 fi;
 
 # If no LetsEncrypt certs are present - generate a set
 if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     echo "No Certificates detected - $(ls /etc/letsencrypt/live/)"
 
-    #TODO Remove Test Cert
-    Command="certbot certonly -v --test-cert --standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos"
+    CertbotParameter=""
+    if [ "${LetsencryptProdCert}" != "true" ]; then
+	CertbotParameter="--test-cert "
+    fi
+	Command="certbot certonly -v ${CertbotParameter}--standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos"
 
     while ! $Command; do
         echo "Command failed, retrying in 10 seconds..."
@@ -30,7 +33,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
 
     /opt/tak/certs/cert-metadata.sh
 
-    mkdir -p "/opt/tak/certs/${HostedDomain}/"
+    mkdir -p "/opt/tak/certs/files/${HostedDomain}/"
 
     openssl x509 \
         -text \
@@ -41,40 +44,50 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
         -export \
         -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem" \
         -inkey "/etc/letsencrypt/live/${HostedDomain}/privkey.pem" \
-        -out "/opt/tak/certs/${HostedDomain}/letsencrypt.p12" \
+        -out "/opt/tak/certs/files/${HostedDomain}/letsencrypt.p12" \
         -name "${HostedDomain}" \
         -password "pass:atakatak"
 fi
 
-if [ ! -f "/opt/tak/certs/${HostedDomain}/letsencrypt.jks" ]; then
-    cp "/etc/letsencrypt/live/${HostedDomain}/"* "/opt/tak/certs/${HostedDomain}/"
+if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
+    cp "/etc/letsencrypt/live/${HostedDomain}/"* "/opt/tak/certs/files/${HostedDomain}/"
 
     keytool \
         -importkeystore \
         -srcstorepass "atakatak" \
         -deststorepass "atakatak" \
-        -destkeystore "/opt/tak/certs/${HostedDomain}/letsencrypt.jks" \
-        -srckeystore "/opt/tak/certs/${HostedDomain}/letsencrypt.p12" \
+        -destkeystore "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" \
+        -srckeystore "/opt/tak/certs/files/${HostedDomain}/letsencrypt.p12" \
         -srcstoretype "pkcs12"
 fi
 
+cd /opt/tak/certs
 if [ ! -f "/opt/tak/certs/files/ca.pem" ]; then
-    CA_NAME="${StackName:-TAKServer}" ./certs/makeRootCa.sh
+    /opt/tak/certs/makeRootCa.sh --ca-name ${StackName:-TAKServer}
+    { yes || :; } | /opt/tak/certs/makeCert.sh ca intermediate-ca
+    { yes || :; } | /opt/tak/certs/makeCert.sh server takserver
+    { yes || :; } | /opt/tak/certs/makeCert.sh client admin
 
-    ./certs/makeCert.sh ca intermediate-ca
-    yes | ./certs/makeCert.sh server takserver
-    yes | ./certs/makeCert.sh client admin
-
-    cp ./certs/files/* /opt/tak/certs/files/
+    aws secretsmanager put-secret-value \
+    --secret-id ${StackName}/tak-admin-cert \
+    --secret-binary fileb://files/admin.p12 || true
 fi
+
+cd /opt/tak
 
 node --version
 node CoreConfig.js
 
-./validateConfig.sh ./CoreConfig.xml
+/opt/tak/validateConfig.sh /opt/tak/CoreConfig.xml
 
-mv ./CoreConfig.xml /opt/tak/CoreConfig.xml
+java -jar /opt/tak/db-utils/SchemaManager.jar upgrade
 
-java -jar ./db-utils/SchemaManager.jar upgrade
+/opt/tak/configureInDocker.sh init &
 
-./configureInDocker.sh init
+SetAdminCommand="java -jar /opt/tak/utils/UserManager.jar certmod -A /opt/tak/certs/files/admin.pem"
+while ! $SetAdminCommand; do
+   echo "Making admin and admin failed, retrying in 10 seconds..."
+   sleep 10
+done
+
+wait


### PR DESCRIPTION
Fixes a bunch of small things to make TAK Server deployable with Fargate. 

This version assumes that the latest release (5.3-Release-24) of the TAKSERVER-DOCKER-xxx.ZIP file has been downloaded from https://tak.gov/products/tak-server and is in the same directory!

Changes:
- Bumped up the PostgreSQL version
- Changed filesystem layout to adopt to release 5.3. Everything is in /opt/tak and only /opt/tak/certs/files is persistent.
- Added port 80 for Letsencrypt
- Added workflow to chose between Letsencrypt Prod and Test cert
- TAK admin.p12 cert is persisted into Secrets Manager
- Various other small fixes

This deploy fully into a working instance. 

What's not working and needs to be addressed in a future version:
- Does not handle Letsencrypt cert renewal. A few options for that would be:
  - Use a certbot [deploy hook](https://eff-certbot.readthedocs.io/en/stable/using.html#renewing-certificates) to call ECR for a forced redeployment via `aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment`.
  - Run an additional container with Nginx reverse proxy and Certbot in front of port 8446
  - Have NLB terminate the SSL connection with an ACM managed cert and forward to an ALB, which then uses an HTTPS target group with port 8446 on the TAK server. 
- Built-in CA renewal currently isn't handled either. 
- More customization options for the TAK server settings are needed. 