### PR TITLE
Support locally downloaded takserver-xxx.zip file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *CoreConfig.xml
 *UserAuthentication.xml
 tak-data/
+takserver-docker-*.zip
 
 # Logs
 logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ ENV NVM_DIR=/usr/local/nvm
 ENV NODE_VERSION=22
 ENV TAK_VERSION=takserver-docker-5.4-RELEASE-5
 
-RUN wget "http://tak-server-releases.s3-website.us-gov-east-1.amazonaws.com/${TAK_VERSION}.zip" \
-    && unzip "./${TAK_VERSION}.zip" \
+RUN if [ ! -e "${TAK_VERSION}.zip" ]; then \
+        wget "http://tak-server-releases.s3-website.us-gov-east-1.amazonaws.com/${TAK_VERSION}.zip"; \
+    fi
+RUN unzip "./${TAK_VERSION}.zip" \
     && rm "./${TAK_VERSION}.zip" \
     && rm -rf "./${TAK_VERSION}/docker" \
     && mv ./${TAK_VERSION}/tak/* ./ \


### PR DESCRIPTION
To support quicker testing as well as the deployment of TAK server version that are not available on http://tak-server-releases.s3-website.us-gov-east-1.amazonaws.com/, support ingesting takserver-xxx.zip files that have been downloaded manually from tak.gov into the local repo folder. 

Necessary changes: 
- Add ```takserver-docker-*.zip``` to the .gitignore file
- Check if ```takserver-docker-*.zip``` exists before attempting download

Tested with ```takserver-docker-5.4-RELEASE-14.zip```