### PR TITLE
Enable LetsEncrypt renewal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *CoreConfig.xml
 *UserAuthentication.xml
 tak-data/
+takserver-docker-*.zip
 
 # Logs
 logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,12 @@ EXPOSE 9001
 
 ENV NVM_DIR=/usr/local/nvm
 ENV NODE_VERSION=22
-ENV TAK_VERSION=takserver-docker-5.4-RELEASE-5
+ENV TAK_VERSION=takserver-docker-5.4-RELEASE-14
 
-RUN wget "http://tak-server-releases.s3-website.us-gov-east-1.amazonaws.com/${TAK_VERSION}.zip" \
-    && unzip "./${TAK_VERSION}.zip" \
+RUN if [ ! -e "${TAK_VERSION}.zip" ]; then \
+        wget "http://tak-server-releases.s3-website.us-gov-east-1.amazonaws.com/${TAK_VERSION}.zip"; \
+    fi
+RUN unzip "./${TAK_VERSION}.zip" \
     && rm "./${TAK_VERSION}.zip" \
     && rm -rf "./${TAK_VERSION}/docker" \
     && mv ./${TAK_VERSION}/tak/* ./ \

--- a/cloudformation/lib/efs.js
+++ b/cloudformation/lib/efs.js
@@ -14,6 +14,42 @@ export default {
                 PerformanceMode: 'generalPurpose'
             }
         },
+        EFSAccessPointTAK: {
+            Type: 'AWS::EFS::AccessPoint',
+            Properties: {
+                FileSystemId: cf.ref('EFSFileSystem'),
+                PosixUser: {
+                    Uid: 0,
+                    Gid: 0
+                },
+                RootDirectory: {
+                    CreationInfo: {
+                        OwnerGid: 0,
+                        OwnerUid: 0,
+                        Permissions: '0777'
+                    },
+                    Path: '/opt/tak/certs/files'
+                }
+            }
+        },
+        EFSAccessPointLetsEncrypt: {
+            Type: 'AWS::EFS::AccessPoint',
+            Properties: {
+                FileSystemId: cf.ref('EFSFileSystem'),
+                PosixUser: {
+                    Uid: 0,
+                    Gid: 0
+                },
+                RootDirectory: {
+                    CreationInfo: {
+                        OwnerGid: 0,
+                        OwnerUid: 0,
+                        Permissions: '0777'
+                    },
+                    Path: '/etc/letsencrypt'
+                }
+            }
+        },
         EFSMountTargetSubnetA: {
             Type: 'AWS::EFS::MountTarget',
             Properties: {

--- a/letsencrypt-deploy-hook-script.sh
+++ b/letsencrypt-deploy-hook-script.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ -z "$ECS_Cluster_Name" ]]; then  
+  echo "ECS_Cluster_Name not set. Exiting script."  
+  exit 1  
+fi
+
+if [[ -z "$ECS_Service_Name" ]]; then  
+  echo "ECS_Service_Name not set. Exiting script."  
+  exit 1  
+fi
+
+aws ecs update-service --cluster $ECS_Cluster_Name --service $ECS_Service_Name --force-new-deployment

--- a/start
+++ b/start
@@ -9,24 +9,15 @@ set -euo pipefail
 
 echo "NodeJS Version: $(node --version)"
 
-# Enusre Certs Directory is preset
+# Ensure TAK certs Directory is present
 if [ -d "/opt/tak/certs/files/" ]; then
     mkdir -p "/opt/tak/certs/files/"
 fi
 
-# Copy EFS Persisted certs to Let's Encrypt Dir
-if [ -d "/opt/tak/certs/files/${HostedDomain}" ]; then
-    mkdir -p "/etc/letsencrypt/live/${HostedDomain}"
-
-    echo "ok - Listing /opt/tak/certs/files/"
-    ls "/opt/tak/certs/files/"
-
-    echo "ok - Listing /opt/tak/certs/files/${HostedDomain}/"
-    ls "/opt/tak/certs/files/${HostedDomain}/"
-
-    echo "ok - Copying ${HostedDomain} to Let's Encrypt Working Dir"
-    cp "/opt/tak/certs/files/${HostedDomain}/"* "/etc/letsencrypt/live/${HostedDomain}/"
-fi;
+# Attempt to restore Certbot Cronjob
+if [ ! -e "/etc/cron.d/certbot" ]; then
+    cp /etc/letsencrypt/certbot.cron /etc/cron.d/certbot || true
+fi
 
 # If LetsEncrypt certs are present - check validity
 if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
@@ -64,13 +55,16 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
         CertbotParameter="--test-cert "
     fi
 
-    Command="certbot certonly -v ${CertbotParameter}--standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos --cert-name ${HostedDomain}"
+    Command="certbot certonly -v ${CertbotParameter}--standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos --cert-name ${HostedDomain} --deploy-hook /opt/tak/letsencrypt-deploy-hook-script.sh"
 
     while ! $Command; do
         echo "not ok - Command failed, retrying in 10 seconds..."
         sleep 10
         node ./Ensure80.js
     done
+
+    # Save Certbot Cronjob
+    cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron
 
     /opt/tak/certs/cert-metadata.sh
 

--- a/start
+++ b/start
@@ -14,9 +14,11 @@ if [ -d "/opt/tak/certs/files/" ]; then
     mkdir -p "/opt/tak/certs/files/"
 fi
 
-# Attempt to restore Certbot Cronjob
+# Attempt to restore Certbot Cronjob or save it, if it exists
 if [ ! -e "/etc/cron.d/certbot" ]; then
     cp /etc/letsencrypt/certbot.cron /etc/cron.d/certbot || true
+else
+    cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron || true
 fi
 
 # If LetsEncrypt certs are present - check validity
@@ -66,6 +68,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     # Save Certbot Cronjob
     cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron
 
+    # Generate TAK certs
     /opt/tak/certs/cert-metadata.sh
 
     mkdir -p "/opt/tak/certs/files/${HostedDomain}/"


### PR DESCRIPTION
Fixes #11 

- Updated ECS task role to allow redeployment of own task
- Added LetsEncrypt deploy hook script that will initiate an ECS task redeployment after the LetsEncrypt certificate was successfully installed
- Made LetsEncrypt configuration in `/etc/letsencrypt` along with the certbot cronjob at `/etc/cron.d/certbot` persistent