### PR TITLE
Asynchronous request of Let's Encrypt certs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+
+ *.md
+ bin/
+ cloudformation/
+ node_modules/
+ oas/
+ .deploy
+ upload
+ docker-compose.yml
+ # Git related files and folder
+ .git
+ .github
+ .gitignore

--- a/CoreConfig.js
+++ b/CoreConfig.js
@@ -27,7 +27,7 @@ $.execSync('yes | keytool -import -file /tmp/AmazonRootCA1.pem -alias AWS -dests
     stdio: 'inherit'
 });
 
-await fsp.rename('/tmp/AmazonRootCA1.jks', '/opt/tak/certs/files/aws-acm-root.jks');
+await fsp.copyFile('/tmp/AmazonRootCA1.jks', '/opt/tak/certs/files/aws-acm-root.jks');
 
 const LDAP_DN = process.env.LDAP_Domain.split('.').map((part) => {
     return `dc=${part}`;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jammy
 RUN apt update \
-    && apt-get install -y emacs-nox net-tools netcat vim certbot curl libxml2-utils unzip nodejs awscli
+    && apt-get install -y cron emacs-nox net-tools vim certbot curl libxml2-utils unzip nodejs awscli
 
 ENV HOME=/opt/tak
 WORKDIR $HOME

--- a/bin/build.js
+++ b/bin/build.js
@@ -4,11 +4,13 @@ import CP from 'child_process';
 process.env.GITSHA = sha();
 
 process.env.Environment = process.env.Environment || 'prod';
+process.env.AWS_PROFILE = process.env.AWS_PROFILE || 'default';
 
 for (const env of [
     'GITSHA',
     'AWS_REGION',
     'AWS_ACCOUNT_ID',
+    'AWS_PROFILE',
     'Environment',
 ]) {
     if (!process.env[env]) {
@@ -28,6 +30,7 @@ function login() {
         const $ = CP.exec(`
             aws ecr get-login-password \
                 --region $\{AWS_REGION\} \
+                --profile $\{AWS_PROFILE\} \
             | docker login \
                 --username AWS \
                 --password-stdin "$\{AWS_ACCOUNT_ID\}.dkr.ecr.$\{AWS_REGION\}.amazonaws.com"
@@ -47,7 +50,7 @@ function tak() {
     return new Promise((resolve, reject) => {
         const $ = CP.exec(`
             docker compose build api \
-            && docker tag tak-api:latest "$\{AWS_ACCOUNT_ID\}.dkr.ecr.$\{AWS_REGION\}.amazonaws.com/coe-ecr-tak:$\{GITSHA\}" \
+            && docker tag takserver:latest "$\{AWS_ACCOUNT_ID\}.dkr.ecr.$\{AWS_REGION\}.amazonaws.com/coe-ecr-tak:$\{GITSHA\}" \
             && docker push "$\{AWS_ACCOUNT_ID\}.dkr.ecr.$\{AWS_REGION\}.amazonaws.com/coe-ecr-tak:$\{GITSHA\}"
         `, (err) => {
             if (err) return reject(err);

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -11,12 +11,12 @@ if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
             echo "ok - Test Cert"
         else
             echo "ok - Production Cert Requested - Test Cert Current - Regenerating"
-            certbot delete --cert-name ${HostedDomain}
+            certbot delete --cert-name ${HostedDomain} --non-interactive
         fi
     else
         if [ "${LetsencryptProdCert}" != "true" ]; then
             echo "ok - Test Cert Requested - Prod Cert Current - Regenerating"
-            certbot delete --cert-name ${HostedDomain}
+            certbot delete --cert-name ${HostedDomain} --non-interactive
         else
             echo "ok - Prod Cert"
         fi

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -2,7 +2,7 @@
 
 # If LetsEncrypt certs are present - check validity
 if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
-    echo "Certbot - Checking validity of existing certs"
+    echo "ok - Certbot - Checking validity of existing certs"
 
     # Extract the issuer from the certificate
     ISSUER=$(openssl x509 -noout -issuer -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem")
@@ -10,24 +10,24 @@ if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     # Check if the issuer is from the Let's Encrypt staging environment
     if echo "$ISSUER" | grep -q "STAGING"; then
         if [ "${LetsencryptProdCert}" != "true" ]; then
-            echo "Certbot - Staging cert exists"
+            echo "ok - Certbot - Staging cert exists"
         else
-            echo "Certbot - Staging cert exists, Production cert requested - Regenerating certs..."
+            echo "ok - Certbot - Staging cert exists, Production cert requested - Regenerating certs..."
             certbot delete --cert-name ${HostedDomain} --non-interactive
         fi
     else
         if [ "${LetsencryptProdCert}" != "true" ]; then
-            echo "Certbot - Production cert exists, Staging cert requested - Regenerating certs..."
+            echo "ok - Certbot - Production cert exists, Staging cert requested - Regenerating certs..."
             certbot delete --cert-name ${HostedDomain} --non-interactive
         else
-            echo "Certbot - Production cert exists"
+            echo "ok - Certbot - Production cert exists"
         fi
     fi
 fi
 
 # If no LetsEncrypt certs are present - generate a set
 if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
-    echo "Certbot - No existing certificates detected - Requesting new one"
+    echo "ok - Certbot - No existing certificates detected - Requesting new one"
 
     # Wait for port TCP/80 to be ready
     node /opt/tak/Ensure80.js
@@ -40,8 +40,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     Command="certbot certonly -v ${CertbotParameter}--standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos --cert-name ${HostedDomain} --deploy-hook /opt/tak/letsencrypt-deploy-hook-script.sh"
 
     while ! $Command; do
-        echo "not ok - Command failed, retrying in 30 seconds..."
-        echo "Certbot - Port TCP/80 not ready for HTTP-01 challenge - Retrying in 30 seconds..."
+        echo "not ok - Certbot - Port TCP/80 not ready for HTTP-01 challenge - Retrying in 30 seconds..."
         sleep 30
         node /opt/tak/Ensure80.js
     done
@@ -53,7 +52,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
 
     rm -rf "/opt/tak/certs/files/${HostedDomain}"
 
-    echo "Certbot - New LetsEncrypt certs issued - Deploying new ECS task..."
+    echo "ok - Certbot - New LetsEncrypt certs issued - Deploying new ECS task..."
 
     aws ecs update-service --cluster $ECS_Cluster_Name --service $ECS_Service_Name --force-new-deployment
 fi

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# If LetsEncrypt certs are present - check validity
+if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
+    # Extract the issuer from the certificate
+    ISSUER=$(openssl x509 -noout -issuer -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem")
+
+    # Check if the issuer is from the Let's Encrypt staging environment
+    if echo "$ISSUER" | grep -q "STAGING"; then
+        if [ "${LetsencryptProdCert}" != "true" ]; then
+            echo "ok - Test Cert"
+        else
+            echo "ok - Production Cert Requested - Test Cert Current - Regenerating"
+            rm -rf "/etc/letsencrypt/live/${HostedDomain}"
+        fi
+    else
+        if [ "${LetsencryptProdCert}" != "true" ]; then
+            echo "ok - Test Cert Requested - Prod Cert Current - Regenerating"
+            rm -rf "/etc/letsencrypt/live/${HostedDomain}"
+        else
+            echo "ok - Prod Cert"
+        fi
+    fi
+fi
+
+# If no LetsEncrypt certs are present - generate a set
+if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
+    echo "ok - No Certificates detected, requesting one"
+
+    # Wait for port TCP/80 to be ready
+    node ./Ensure80.js
+
+    CertbotParameter=""
+    if [ "${LetsencryptProdCert}" != "true" ]; then
+        CertbotParameter="--test-cert "
+    fi
+
+    Command="certbot certonly -v ${CertbotParameter}--standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos --cert-name ${HostedDomain} --deploy-hook /opt/tak/letsencrypt-deploy-hook-script.sh"
+
+    while ! $Command; do
+        echo "not ok - Command failed, retrying in 10 seconds..."
+        sleep 10
+        node ./Ensure80.js
+    done
+
+    # Save Certbot Cronjob
+    cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron
+
+    # Force generation of new TAK certs from LetsEncrypt certs on new task deployment
+
+    rm -rf "/opt/tak/certs/files/${HostedDomain}"
+
+    echo "ok - New LetsEncrypt certs issued. Deploying new task."
+
+    aws ecs update-service --cluster $ECS_Cluster_Name --service $ECS_Service_Name --force-new-deployment
+fi

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -2,30 +2,32 @@
 
 # If LetsEncrypt certs are present - check validity
 if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
+    echo "Certbot - Checking validity of existing certs"
+
     # Extract the issuer from the certificate
     ISSUER=$(openssl x509 -noout -issuer -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem")
 
     # Check if the issuer is from the Let's Encrypt staging environment
     if echo "$ISSUER" | grep -q "STAGING"; then
         if [ "${LetsencryptProdCert}" != "true" ]; then
-            echo "ok - Test Cert"
+            echo "Certbot - Staging cert exists"
         else
-            echo "ok - Production Cert Requested - Test Cert Current - Regenerating"
+            echo "Certbot - Staging cert exists, Production cert requested - Regenerating certs..."
             certbot delete --cert-name ${HostedDomain} --non-interactive
         fi
     else
         if [ "${LetsencryptProdCert}" != "true" ]; then
-            echo "ok - Test Cert Requested - Prod Cert Current - Regenerating"
+            echo "Certbot - Production cert exists, Staging cert requested - Regenerating certs..."
             certbot delete --cert-name ${HostedDomain} --non-interactive
         else
-            echo "ok - Prod Cert"
+            echo "Certbot - Production cert exists"
         fi
     fi
 fi
 
 # If no LetsEncrypt certs are present - generate a set
 if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
-    echo "ok - No Certificates detected, requesting one"
+    echo "Certbot - No existing certificates detected - Requesting new one"
 
     # Wait for port TCP/80 to be ready
     node /opt/tak/Ensure80.js
@@ -39,6 +41,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
 
     while ! $Command; do
         echo "not ok - Command failed, retrying in 30 seconds..."
+        echo "Certbot - Port TCP/80 not ready for HTTP-01 challenge - Retrying in 30 seconds..."
         sleep 30
         node /opt/tak/Ensure80.js
     done
@@ -50,7 +53,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
 
     rm -rf "/opt/tak/certs/files/${HostedDomain}"
 
-    echo "ok - New LetsEncrypt certs issued. Deploying new task."
+    echo "Certbot - New LetsEncrypt certs issued - Deploying new ECS task..."
 
     aws ecs update-service --cluster $ECS_Cluster_Name --service $ECS_Service_Name --force-new-deployment
 fi

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -38,8 +38,8 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     Command="certbot certonly -v ${CertbotParameter}--standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos --cert-name ${HostedDomain} --deploy-hook /opt/tak/letsencrypt-deploy-hook-script.sh"
 
     while ! $Command; do
-        echo "not ok - Command failed, retrying in 10 seconds..."
-        sleep 10
+        echo "not ok - Command failed, retrying in 30 seconds..."
+        sleep 30
         node /opt/tak/Ensure80.js
     done
 

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -28,7 +28,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     echo "ok - No Certificates detected, requesting one"
 
     # Wait for port TCP/80 to be ready
-    node ./Ensure80.js
+    node /opt/tak/Ensure80.js
 
     CertbotParameter=""
     if [ "${LetsencryptProdCert}" != "true" ]; then
@@ -40,7 +40,7 @@ if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     while ! $Command; do
         echo "not ok - Command failed, retrying in 10 seconds..."
         sleep 10
-        node ./Ensure80.js
+        node /opt/tak/Ensure80.js
     done
 
     # Save Certbot Cronjob

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -10,7 +10,7 @@ if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
     # Check if the issuer is from the Let's Encrypt staging environment
     if echo "$ISSUER" | grep -q "STAGING"; then
         if [ "${LetsencryptProdCert}" != "true" ]; then
-            echo "ok - Certbot - Staging cert exists"
+            echo "ok - Certbot - Staging cert exists, Staging cert requested - Nothing to be done"
         else
             echo "ok - Certbot - Staging cert exists, Production cert requested - Regenerating certs..."
             certbot delete --cert-name ${HostedDomain} --non-interactive
@@ -20,7 +20,7 @@ if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
             echo "ok - Certbot - Production cert exists, Staging cert requested - Regenerating certs..."
             certbot delete --cert-name ${HostedDomain} --non-interactive
         else
-            echo "ok - Certbot - Production cert exists"
+            echo "ok - Certbot - Production cert exists, Production cert requested - Nothing to be done"
         fi
     fi
 fi

--- a/letsencrypt-request-cert.sh
+++ b/letsencrypt-request-cert.sh
@@ -11,12 +11,12 @@ if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
             echo "ok - Test Cert"
         else
             echo "ok - Production Cert Requested - Test Cert Current - Regenerating"
-            rm -rf "/etc/letsencrypt/live/${HostedDomain}"
+            certbot delete --cert-name ${HostedDomain}
         fi
     else
         if [ "${LetsencryptProdCert}" != "true" ]; then
             echo "ok - Test Cert Requested - Prod Cert Current - Regenerating"
-            rm -rf "/etc/letsencrypt/live/${HostedDomain}"
+            certbot delete --cert-name ${HostedDomain}
         else
             echo "ok - Prod Cert"
         fi

--- a/start
+++ b/start
@@ -65,7 +65,7 @@ if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
     else 
         # No previous LetsEncrypt cert exists, use the self-signed one
         echo "ok - Using self-signed certs instead of LetsEncrypt"
-        mkdir /opt/tak/certs/files/${HostedDomain}
+        mkdir /opt/tak/certs/files/${HostedDomain} || true
         cp /opt/tak/certs/files/takserver.jks /opt/tak/certs/files/${HostedDomain}/letsencrypt.jks || true
     fi
 fi

--- a/start
+++ b/start
@@ -65,6 +65,7 @@ if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
     else 
         # No previous LetsEncrypt cert exists, use the self-signed one
         echo "ok - Using self-signed certs instead of LetsEncrypt"
+        mkdir /opt/tak/certs/files/${HostedDomain}
         cp /opt/tak/certs/files/takserver.jks /opt/tak/certs/files/${HostedDomain}/letsencrypt.jks || true
     fi
 fi

--- a/start
+++ b/start
@@ -39,6 +39,7 @@ fi
 # Restore LetsEncrypt cert
 # If no previous LetsEncrypt certs exist, use the self-signed ones
 if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
+    mkdir /opt/tak/certs/files/${HostedDomain} || true
     if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
         # Previous LetsEncrypt cert exists, convert it
         echo "ok - Converting LetsEncrypt certs to TAK format"
@@ -65,7 +66,6 @@ if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
     else 
         # No previous LetsEncrypt cert exists, use the self-signed one
         echo "ok - Using self-signed certs instead of LetsEncrypt"
-        mkdir /opt/tak/certs/files/${HostedDomain} || true
         cp /opt/tak/certs/files/takserver.jks /opt/tak/certs/files/${HostedDomain}/letsencrypt.jks || true
     fi
 fi

--- a/start
+++ b/start
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-echo "NodeJS Version: $(node --version)"
+echo "NodeJS - Version: $(node --version)"
 
 # Ensure TAK certs Directory is present
 if [ -d "/opt/tak/certs/files/" ]; then
@@ -15,6 +15,7 @@ if [ -d "/opt/tak/certs/files/" ]; then
 fi
 
 # Attempt to restore Certbot Cronjob or save it, if it exists
+echo "Certbot - Restoring cronjob"
 if [ ! -e "/etc/cron.d/certbot" ]; then
     cp /etc/letsencrypt/certbot.cron /etc/cron.d/certbot || true
 else
@@ -24,6 +25,7 @@ fi
 # Check if TAK certs exist, otherwise generate them
 cd /opt/tak/certs
 if [ ! -f "/opt/tak/certs/files/ca.pem" ]; then
+    echo "TAK Server - Generating new certificates"
     /opt/tak/certs/cert-metadata.sh
     mkdir -p "/opt/tak/certs/files/${HostedDomain}/"
     /opt/tak/certs/makeRootCa.sh --ca-name ${StackName:-TAKServer}
@@ -42,7 +44,7 @@ if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
     mkdir /opt/tak/certs/files/${HostedDomain} || true
     if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
         # Previous LetsEncrypt cert exists, convert it
-        echo "ok - Converting LetsEncrypt certs to TAK format"
+        echo "TAK Server - Converting LetsEncrypt certs to TAK format"
         openssl x509 \
             -text \
             -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem" \
@@ -65,7 +67,7 @@ if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
             -srcstoretype "pkcs12" 
     else 
         # No previous LetsEncrypt cert exists, use the self-signed one
-        echo "ok - Using self-signed certs instead of LetsEncrypt"
+        echo "TAK Server - Using self-signed certs instead of LetsEncrypt certs"
         cp /opt/tak/certs/files/takserver.jks /opt/tak/certs/files/${HostedDomain}/letsencrypt.jks || true
     fi
 fi
@@ -73,8 +75,8 @@ fi
 # Request LetsEncrypt certs in background
 /opt/tak/letsencrypt-request-cert.sh &
 
+echo "TAK Server - Generating config file"
 cd /opt/tak
-
 node CoreConfig.js
 
 /opt/tak/validateConfig.sh /opt/tak/CoreConfig.xml
@@ -82,14 +84,16 @@ node CoreConfig.js
 java -jar /opt/tak/db-utils/SchemaManager.jar validate
 java -jar /opt/tak/db-utils/SchemaManager.jar upgrade
 
+echo "TAK Server - Starting server"
 /opt/tak/configureInDocker.sh init &
 
+echo "TAK Server - Elevating admin user privileges"
 SetAdminCommand="java -jar /opt/tak/utils/UserManager.jar certmod -A /opt/tak/certs/files/admin.pem"
 while ! $SetAdminCommand; do
-   echo "Making admin and admin failed, retrying in 10 seconds..."
+   echo "TAK Server - Elevating admin user privileges failed, retrying in 10 seconds..."
    sleep 10
 done
 
 # Run cron in foreground
-echo "ok - Starting cron for cert renewals"
+echo "Certbot - Starting cron for certbot renewals"
 /usr/sbin/cron -f

--- a/start
+++ b/start
@@ -21,12 +21,11 @@ else
     cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron || true
 fi
 
-/opt/tak/certs/cert-metadata.sh
-mkdir -p "/opt/tak/certs/files/${HostedDomain}/"
-
-# Check if TAK certs exist and generate them if not
+# Check if TAK certs exist, otherwise generate them
 cd /opt/tak/certs
 if [ ! -f "/opt/tak/certs/files/ca.pem" ]; then
+    /opt/tak/certs/cert-metadata.sh
+    mkdir -p "/opt/tak/certs/files/${HostedDomain}/"
     /opt/tak/certs/makeRootCa.sh --ca-name ${StackName:-TAKServer}
     { yes || :; } | /opt/tak/certs/makeCert.sh ca intermediate-ca
     { yes || :; } | /opt/tak/certs/makeCert.sh server takserver
@@ -90,4 +89,6 @@ while ! $SetAdminCommand; do
    sleep 10
 done
 
-wait
+# Run cron in foreground
+echo "ok - Starting cron for cert renewals"
+/usr/sbin/cron -f

--- a/start
+++ b/start
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-echo "NodeJS - Version: $(node --version)"
+echo "ok - NodeJS - Version: $(node --version)"
 
 # Ensure TAK certs Directory is present
 if [ -d "/opt/tak/certs/files/" ]; then
@@ -15,7 +15,7 @@ if [ -d "/opt/tak/certs/files/" ]; then
 fi
 
 # Attempt to restore Certbot Cronjob or save it, if it exists
-echo "Certbot - Restoring cronjob"
+echo "ok - Certbot - Restoring cronjob"
 if [ ! -e "/etc/cron.d/certbot" ]; then
     cp /etc/letsencrypt/certbot.cron /etc/cron.d/certbot || true
 else
@@ -25,7 +25,7 @@ fi
 # Check if TAK certs exist, otherwise generate them
 cd /opt/tak/certs
 if [ ! -f "/opt/tak/certs/files/ca.pem" ]; then
-    echo "TAK Server - Generating new certificates"
+    echo "ok - TAK Server - Generating new certificates"
     /opt/tak/certs/cert-metadata.sh
     mkdir -p "/opt/tak/certs/files/${HostedDomain}/"
     /opt/tak/certs/makeRootCa.sh --ca-name ${StackName:-TAKServer}
@@ -44,7 +44,7 @@ if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
     mkdir /opt/tak/certs/files/${HostedDomain} || true
     if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
         # Previous LetsEncrypt cert exists, convert it
-        echo "TAK Server - Converting LetsEncrypt certs to TAK format"
+        echo "ok - TAK Server - Converting LetsEncrypt certs to TAK format"
         openssl x509 \
             -text \
             -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem" \
@@ -67,7 +67,7 @@ if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
             -srcstoretype "pkcs12" 
     else 
         # No previous LetsEncrypt cert exists, use the self-signed one
-        echo "TAK Server - Using self-signed certs instead of LetsEncrypt certs"
+        echo "ok - TAK Server - Using self-signed certs instead of LetsEncrypt certs"
         cp /opt/tak/certs/files/takserver.jks /opt/tak/certs/files/${HostedDomain}/letsencrypt.jks || true
     fi
 fi
@@ -75,7 +75,7 @@ fi
 # Request LetsEncrypt certs in background
 /opt/tak/letsencrypt-request-cert.sh &
 
-echo "TAK Server - Generating config file"
+echo "ok - TAK Server - Generating config file"
 cd /opt/tak
 node CoreConfig.js
 
@@ -84,16 +84,16 @@ node CoreConfig.js
 java -jar /opt/tak/db-utils/SchemaManager.jar validate
 java -jar /opt/tak/db-utils/SchemaManager.jar upgrade
 
-echo "TAK Server - Starting server"
+echo "ok - TAK Server - Starting server"
 /opt/tak/configureInDocker.sh init &
 
-echo "TAK Server - Elevating admin user privileges"
+echo "ok - TAK Server - Elevating admin user privileges"
 SetAdminCommand="java -jar /opt/tak/utils/UserManager.jar certmod -A /opt/tak/certs/files/admin.pem"
 while ! $SetAdminCommand; do
-   echo "TAK Server - Elevating admin user privileges failed, retrying in 10 seconds..."
+   echo "not ok - TAK Server - Elevating admin user privileges failed, retrying in 10 seconds..."
    sleep 10
 done
 
 # Run cron in foreground
-echo "Certbot - Starting cron for certbot renewals"
+echo "ok - Certbot - Starting cron for certbot renewals"
 /usr/sbin/cron -f

--- a/start
+++ b/start
@@ -7,6 +7,7 @@
 
 set -euo pipefail
 
+echo "ok - TAK Server - New ECS Task starting..."
 echo "ok - NodeJS - Version: $(node --version)"
 
 # Ensure TAK certs Directory is present
@@ -87,12 +88,15 @@ java -jar /opt/tak/db-utils/SchemaManager.jar upgrade
 echo "ok - TAK Server - Starting server"
 /opt/tak/configureInDocker.sh init &
 
-echo "ok - TAK Server - Elevating admin user privileges"
+echo "ok - TAK Server - Starting to elevate admin user privileges..."
 SetAdminCommand="java -jar /opt/tak/utils/UserManager.jar certmod -A /opt/tak/certs/files/admin.pem"
 while ! $SetAdminCommand; do
    echo "not ok - TAK Server - Elevating admin user privileges failed, retrying in 10 seconds..."
    sleep 10
 done
+echo "ok - TAK Server - Elevating admin user privileges succeeded"
+
+echo "ok - TAK Server - New ECS Task successfully started"
 
 # Run cron in foreground
 echo "ok - Certbot - Starting cron for certbot renewals"

--- a/start
+++ b/start
@@ -21,84 +21,10 @@ else
     cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron || true
 fi
 
-# If LetsEncrypt certs are present - check validity
-if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
-    # Extract the issuer from the certificate
-    ISSUER=$(openssl x509 -noout -issuer -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem")
+/opt/tak/certs/cert-metadata.sh
+mkdir -p "/opt/tak/certs/files/${HostedDomain}/"
 
-    # Check if the issuer is from the Let's Encrypt staging environment
-    if echo "$ISSUER" | grep -q "STAGING"; then
-        if [ "${LetsencryptProdCert}" != "true" ]; then
-            echo "ok - Test Cert"
-        else
-            echo "ok - Production Cert Requested - Test Cert Current - Regenerating"
-            rm -rf "/etc/letsencrypt/live/${HostedDomain}"
-            rm -rf "/opt/tak/certs/files/${HostedDomain}"
-        fi
-    else
-        if [ "${LetsencryptProdCert}" != "true" ]; then
-            echo "ok - Test Cert Requested - Prod Cert Current - Regenerating"
-            rm -rf "/etc/letsencrypt/live/${HostedDomain}"
-            rm -rf "/opt/tak/certs/files/${HostedDomain}"
-        else
-            echo "ok - Prod Cert"
-        fi
-    fi
-fi
-
-# If no LetsEncrypt certs are present - generate a set
-if [ ! -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
-    echo "ok - No Certificates detected, requesting one"
-
-    node ./Ensure80.js
-
-    CertbotParameter=""
-    if [ "${LetsencryptProdCert}" != "true" ]; then
-        CertbotParameter="--test-cert "
-    fi
-
-    Command="certbot certonly -v ${CertbotParameter}--standalone -d ${HostedDomain} --email ${HostedEmail} --non-interactive --agree-tos --cert-name ${HostedDomain} --deploy-hook /opt/tak/letsencrypt-deploy-hook-script.sh"
-
-    while ! $Command; do
-        echo "not ok - Command failed, retrying in 10 seconds..."
-        sleep 10
-        node ./Ensure80.js
-    done
-
-    # Save Certbot Cronjob
-    cp /etc/cron.d/certbot /etc/letsencrypt/certbot.cron
-
-    # Generate TAK certs
-    /opt/tak/certs/cert-metadata.sh
-
-    mkdir -p "/opt/tak/certs/files/${HostedDomain}/"
-
-    openssl x509 \
-        -text \
-        -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem" \
-        -noout
-
-    openssl pkcs12 \
-        -export \
-        -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem" \
-        -inkey "/etc/letsencrypt/live/${HostedDomain}/privkey.pem" \
-        -out "/opt/tak/certs/files/${HostedDomain}/letsencrypt.p12" \
-        -name "${HostedDomain}" \
-        -password "pass:atakatak"
-fi
-
-if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
-    cp "/etc/letsencrypt/live/${HostedDomain}/"* "/opt/tak/certs/files/${HostedDomain}/"
-
-    keytool \
-        -importkeystore \
-        -srcstorepass "atakatak" \
-        -deststorepass "atakatak" \
-        -destkeystore "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" \
-        -srckeystore "/opt/tak/certs/files/${HostedDomain}/letsencrypt.p12" \
-        -srcstoretype "pkcs12"
-fi
-
+# Check if TAK certs exist and generate them if not
 cd /opt/tak/certs
 if [ ! -f "/opt/tak/certs/files/ca.pem" ]; then
     /opt/tak/certs/makeRootCa.sh --ca-name ${StackName:-TAKServer}
@@ -110,6 +36,42 @@ if [ ! -f "/opt/tak/certs/files/ca.pem" ]; then
         --secret-id ${StackName}/tak-admin-cert \
         --secret-binary fileb://files/admin.p12 || true
 fi
+
+# Restore LetsEncrypt cert
+# If no previous LetsEncrypt certs exist, use the self-signed ones
+if [ ! -f "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" ]; then
+    if [ -d "/etc/letsencrypt/live/${HostedDomain}" ]; then
+        # Previous LetsEncrypt cert exists, convert it
+        echo "ok - Converting LetsEncrypt certs to TAK format"
+        openssl x509 \
+            -text \
+            -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem" \
+            -noout
+
+        openssl pkcs12 \
+            -export \
+            -in "/etc/letsencrypt/live/${HostedDomain}/fullchain.pem" \
+            -inkey "/etc/letsencrypt/live/${HostedDomain}/privkey.pem" \
+            -out "/opt/tak/certs/files/${HostedDomain}/letsencrypt.p12" \
+            -name "${HostedDomain}" \
+            -password "pass:atakatak"
+
+        keytool \
+            -importkeystore \
+            -srcstorepass "atakatak" \
+            -deststorepass "atakatak" \
+            -destkeystore "/opt/tak/certs/files/${HostedDomain}/letsencrypt.jks" \
+            -srckeystore "/opt/tak/certs/files/${HostedDomain}/letsencrypt.p12" \
+            -srcstoretype "pkcs12" 
+    else 
+        # No previous LetsEncrypt cert exists, use the self-signed one
+        echo "ok - Using self-signed certs instead of LetsEncrypt"
+        cp /opt/tak/certs/files/takserver.jks /opt/tak/certs/files/${HostedDomain}/letsencrypt.jks || true
+    fi
+fi
+
+# Request LetsEncrypt certs in background
+/opt/tak/letsencrypt-request-cert.sh &
 
 cd /opt/tak
 


### PR DESCRIPTION
Moves Let's Encrypt cert requests via certbot into an asynchronous script that does not block the Docker entrypoint.

That way the TAK server will come up with whatever old certificate it had and make the NLB health checks happy. In the background the new script `letsencrypt-request-cert.sh` will attempt to issue/re-issue a LetsEncrypt cert. Once that's successful it will call for a task replacement via `aws ecs update-service`.

To make this work during first boot, the standard self-signed certificate is being used. This is necessary as no LetsEncrypt-issued cert is available yet.

With that the new workflow is: 

- **First boot:** TAK comes up with the self-signed cert and is usable. Once DNS name is correctly in place and HTTP-01 challenge is usable, the self-signed cert is replaced with a LetsEncrypt cert and the task replaced.
- **Prod/Dev cert change:** TAK comes up with the previous dev or prod cert and is usable. After validation that the DNS name is correctly in place and HTTP-01 challenge is usable, the previous dev or prod cert is replaced with a new LetsEncrypt cert and the task replaced.

This addresses:
- item #20

In addition small fixed are included:
- Cron daemon installed, which was missed in #11
- `fsp.rename` swapped for `fsp.copyFile` to address #24
- Added `.dockerignore` file to prevent unneeded files from making it into the docker image
- Normalized script debugging output
- Fixed build script