### PR TITLE
Add support for RDS Multi-AZ deployments

### DIFF
--- a/cloudformation/lib/db.js
+++ b/cloudformation/lib/db.js
@@ -15,6 +15,12 @@ export default {
             Description: 'PostgreSQL database engine version',
             Type: 'String',
             Default: '17.4'
+        },
+        DatabaseMultiAZ: {
+            Description: 'PostgreSQL database as a Multi-AZ deployment',
+            Type: 'String',
+            AllowedValues: ['true', 'false'],
+            Default: 'false'
         }
     },
     Resources: {
@@ -76,6 +82,7 @@ export default {
                 StorageEncrypted: true,
                 MasterUsername: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/rds/secret:SecretString:username:AWSCURRENT}}'),
                 MasterUserPassword: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/rds/secret:SecretString:password:AWSCURRENT}}'),
+                MultiAZ: cf.ref('DatabaseMultiAZ'),
                 PreferredMaintenanceWindow: 'Sun:23:00-Sun:23:30',
                 PreferredBackupWindow: '22:00-23:00',
                 EnablePerformanceInsights: true,


### PR DESCRIPTION
Add CloudFormation template support for [RDS Multi-AZ](https://aws.amazon.com/rds/features/multi-az/) deployments, which is recommended for productions usage. 