### PR TITLE
Move ECS service to private subnet

### DIFF
--- a/cloudformation/lib/service.js
+++ b/cloudformation/lib/service.js
@@ -414,13 +414,13 @@ export default {
                 DesiredCount: 1,
                 NetworkConfiguration: {
                     AwsvpcConfiguration: {
-                        AssignPublicIp: 'ENABLED',
+                        AssignPublicIp: 'DISABLED',
                         SecurityGroups: [
                             cf.importValue(cf.join(['coe-tak-network-', cf.ref('Environment'), '-service-sg']))
                         ],
                         Subnets:  [
-                            cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-subnet-public-a'])),
-                            cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-subnet-public-b']))
+                            cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-subnet-private-a'])),
+                            cf.importValue(cf.join(['coe-vpc-', cf.ref('Environment'), '-subnet-private-b']))
                         ]
                     }
                 },


### PR DESCRIPTION
Move ECS service from public to private subnet. As a result disable assignment of public IP for the task itself. External connectivity will be solely via the NLB - which is in the public subnet. 